### PR TITLE
Fix list template

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -25,7 +25,7 @@
 </header>
 
 <main class="content" role="main">
-    {{ $paginator := .Paginate (where .Data.Pages "Section" "post") }}
+    {{ $paginator := .Paginator }}
 
 	<div class="extra-pagination inner">
     {{ partial "pagination.html" $paginator }}


### PR DESCRIPTION
The list.html used the paginator with a where clause with section "post".

This panics for sites without secion post, and the plain .Paginator is what you'd really want (will always contain the relevant content
for the given section or taxonomy.