### PR TITLE
Fixed #12: css class file names not matching.

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,7 +27,7 @@
 
 
 
-  <article class="{{.Type}}">
+  <article class="post">
 
     <header class="post-header">
         <h1 class="post-title">{{.Title}}</h1>


### PR DESCRIPTION
For some reason the class of an article was set to the name of the Type of the article.

This caused all articles of a different class to have some layout issues (most noticeably: the did not have a margin-left).