### PR TITLE
Allow to set custom RSS-Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Copyright = "All rights reserved - 2015"
   bio= "my bio"
   logo = "images/logo.png"
   googleAnalyticsUserID = "UA-79101-12"
+  # Optional RSS-Link, if not provided it defaults to the standard index.xml
+  RSSLink = "http://feeds.feedburner.com/..." 
   githubName = "vjeantet"
   twitterName = "vjeantet"
   # set true if you are not proud of using Hugo (true will hide the footer note "Proudly published with HUGO.....")

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -10,6 +10,11 @@
             </li>
         {{end}}
     </ul>
+    
+    {{ if .Site.Params.RSSLink}}
+    <a class="subscribe-button icon-feed" href="{{.Site.Params.RSSLink }}">Subscribe</a> </div>
+    {{else}}
     <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{.RSSLink}}{{else}}{{ .Site.BaseUrl }}index.xml{{end}}">Subscribe</a>
+    {{end}}
 </div>
 <span class="nav-cover"></span>


### PR DESCRIPTION
If you are using an external feed aggregator, you were not able to customize the link, with this commit it is possible to set Params -> RSSLink to a value of choice. It is completely optional, so it would use the normal .../index.xml.