### PR TITLE
Add inconsolata to the list of google fonts

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -34,7 +34,7 @@
 	  <link rel="apple-touch-icon" href="{{.Site.BaseUrl}}images/apple-touch-icon.png" />
     
     <link rel="stylesheet" type="text/css" href="{{.Site.BaseUrl}}css/screen.css" />
-    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400" />
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400|Inconsolata" />
 
 
     {{ if .Site.Params.RSSLink}}


### PR DESCRIPTION
Fetching inconsolata font as well; along with the other google fonts,
this clears up the issue in some devices which don't have a good
monospaced font

Thanks for porting this theme to hugo. Primarily I saw using the theme to render code fell back to sans serif fonts in my mobile device; which kind of looked messy. Let me know if this is okay or if there are alternatives