### PR TITLE
removed needless {{ .Site.BaseUrl }} from layouts (make it work with relative path)

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -8,7 +8,7 @@
     </section>
     <footer class="post-meta">
         {{if .Site.Params.logo }}
-            <img class="author-thumb" src="{{ .Site.BaseUrl }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
+            <img class="author-thumb" src="{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
         {{end}}
         {{if .Site.Params.author}}
             {{.Site.Params.author}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -10,7 +10,7 @@
 {{end}}
     <nav class="main-nav overlay clearfix">
       {{ if .Site.Params.logo }}
-        <a class="blog-logo" href="{{.Site.BaseUrl}}"><img src="{{.Site.BaseUrl}}{{ .Site.Params.logo }}" alt="Home" /></a>
+        <a class="blog-logo" href="{{.Site.BaseUrl}}"><img src="{{ .Site.Params.logo }}" alt="Home" /></a>
       {{end}}
       {{ if .Site.Menus.main }}
           <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,12 +10,12 @@
 {{end}}
 
   {{ if .Site.Params.logo }}
-      <a class="blog-logo" href="{{.Site.BaseUrl}}"><img src="{{.Site.BaseUrl}}{{ .Site.Params.logo }}" alt="Home" /></a>
+      <a class="blog-logo" href="{{.Site.BaseUrl}}"><img src="{{ .Site.Params.logo }}" alt="Home" /></a>
   {{end}}
   {{ if .Site.Menus.main }}
       <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>
   {{else}}
-      <a class="menu-button icon-feed" href="{{ .Site.BaseUrl }}index.xml">&nbsp;&nbsp;Subscribe</a>
+      <a class="menu-button icon-feed" href="index.xml">&nbsp;&nbsp;Subscribe</a>
   {{end}}
   </nav>
 </header>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,14 +1,14 @@
 {{ partial "header.html" . }}
 
 {{if .Site.Params.cover}}
-<header class="main-header " style="background-image: url({{.Site.BaseUrl}}{{.Site.Params.cover}})">
+<header class="main-header " style="background-image: url({{.Site.Params.cover}})">
 {{else}}
 <header class="main-header no-cover">
 {{end}}
     
     <nav class="main-nav overlay clearfix">
         {{ if .Site.Params.logo }}
-            <a class="blog-logo" href="{{ .Permalink }}"><img src="{{.Site.BaseUrl}}{{ .Site.Params.logo }}" alt="Blog Logo" /></a>
+            <a class="blog-logo" href="{{ .Permalink }}"><img src="{{ .Site.Params.logo }}" alt="Blog Logo" /></a>
         {{end}}
         {{ if .Site.Menus.main }}
             <a class="menu-button" href="#"><span class="burger">&#9776;</span><span class="word">Menu</span></a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,9 +5,9 @@
         {{end}}
     </footer>
     </div>
-    <script type="text/javascript" src="{{.Site.BaseUrl}}js/jquery.js"></script>
-    <script type="text/javascript" src="{{.Site.BaseUrl}}js/jquery.fitvids.js"></script>
-    <script type="text/javascript" src="{{.Site.BaseUrl}}js/index.js"></script>
+    <script type="text/javascript" src="js/jquery.js"></script>
+    <script type="text/javascript" src="js/jquery.fitvids.js"></script>
+    <script type="text/javascript" src="js/index.js"></script>
 
 </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -30,10 +30,10 @@
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link rel="shortcut icon" href="{{.Site.BaseUrl}}images/favicon.ico">
-	  <link rel="apple-touch-icon" href="{{.Site.BaseUrl}}images/apple-touch-icon.png" />
+    <link rel="shortcut icon" href="images/favicon.ico">
+	  <link rel="apple-touch-icon" href="images/apple-touch-icon.png" />
     
-    <link rel="stylesheet" type="text/css" href="{{.Site.BaseUrl}}css/screen.css" />
+    <link rel="stylesheet" type="text/css" href="css/screen.css" />
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400" />
 
 
@@ -41,7 +41,7 @@
         <link href="{{.Site.Params.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{else}}
       {{ if ne .Url "/" }}
-          <link href="{{ .Site.BaseUrl }}index.xml" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+          <link href="index.xml" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
       {{ end }}
       {{if .IsNode}}
         <link href="{{.RSSLink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .Url "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -14,7 +14,7 @@
     {{ if .Site.Params.RSSLink}}
     <a class="subscribe-button icon-feed" href="{{.Site.Params.RSSLink }}">Subscribe</a> </div>
     {{else}}
-    <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{.RSSLink}}{{else}}{{ .Site.BaseUrl }}index.xml{{end}}">Subscribe</a>
+    <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{.RSSLink}}{{else}}index.xml{{end}}">Subscribe</a>
     {{end}}
 </div>
 <span class="nav-cover"></span>


### PR DESCRIPTION
It is not the problem if baseurl(of config.toml) ends with domain like 'http://blog.com/'.
But it breaks theme if you give it a path like 'http://blog.com/casper'.

For example:
If baseurl in config is 'http://blog.com/casper'
the code below in layouts/partials/header.html
```
    <link rel="stylesheet" type="text/css" href="{{.Site.BaseUrl}}css/screen.css" />
```

will be
```
    <link rel="stylesheet" type="text/css" href="http://blog.com/caspercss/screen.css" />
```

Even if  you change the baseurl to 'http://blog.com/casper/' it does not work at all.
Just the same thing happens.

so I've removed needless part and the first code has become
```
    <link rel="stylesheet" type="text/css" href="css/screen.css" />
```
It works for all of 'http://blog.com/' and 'http://blog.com/casper'.