### PR TITLE
Adding noauthor and multiple author capability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,25 @@ Copyright = "All rights reserved - 2015"
 
 Example : [config.toml](https://github.com/vjeantet/vjeantet.fr/blob/master/config.toml)
 
+## Multiple authors configuration
+
+In addition to providing data for a single author as shown in the example above, multiple authors
+can be configured via data/authors/\*.(yml, toml, json) entries. If the key provided in
+.Site.Params.author matched a data/authors/\* entry, it will be used as the default. Overrides
+per page can be done by a simple author = other_author_key entry in the front matter. For those
+pages where you want to omit the author block completely, a .Params.noauthor entry is also
+available.
+
+Example author definition file:
+
+``` yml
+name: John Doe
+bio: The most uninteresting man in the world.
+location: Normal, IL
+website: http://example.com
+
+```
+
 ## Menu configuration
 
 On top right of the screen, a "Subscribe" button is displayed with a link to the RSS feed.

--- a/data/authors/example.yml
+++ b/data/authors/example.yml
@@ -1,0 +1,4 @@
+name: "John Doe"
+bio: "The most generic man in the world"
+location: "Normal, Il"
+website: "http://example.com"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -57,19 +57,7 @@
     </figure>
     {{end}}
 
-
-    <section class="author">
-        <h4><a href="{{.Site.BaseURL}}">{{.Site.Params.author}}</a></h4>
-        {{if .Site.Params.bio}}
-            <p>{{.Site.Params.bio}}</p>
-        {{else}}
-            <p>Read <a href="{{.Site.BaseURL}}">more posts</a> by this author.</p>
-        {{end}}
-        <div class="author-meta">
-            {{if .Site.Params.authorlocation}}<span class="author-location icon-location">{{.Site.Params.authorlocation}}</span>{{end}}
-            {{if .Site.Params.authorwebsite}}<span class="author-link icon-link"><a href="{{.Site.Params.authorwebsite}}">{{.Site.Params.authorwebsite}}</a></span>{{end}}
-        </div>
-    </section>
+    {{ partial "author.html" . }}
 
     {{ if ne .Params.share false}}
     <section class="share">

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,0 +1,19 @@
+{{ if not .Params.noauthor }}
+{{$author := index .Site.Data.authors (or .Params.author .Site.Params.author)}}
+{{$authorname := or $author.name .Site.Params.author }}
+{{$authorbio := or $author.bio .Site.Params.bio }}
+{{$authorlocation := or $author.location .Site.Params.authorlocation }}
+{{$authorwebsite := or $author.website .Site.Params.authorwebsite }}
+<section class="author">
+  <h4><a href="{{.Site.BaseURL}}">{{$authorname}}</a></h4>
+  {{if $authorbio}}
+  <p>{{$authorbio}}</p>
+  {{else}}
+  <p>Read <a href="{{.Site.BaseURL}}">more posts</a> by this author.</p>
+  {{end}}
+  <div class="author-meta">
+    {{with $authorlocation}}<span class="author-location icon-location">{{.}}</span>{{end}}
+    {{with $authorwebsite}}<span class="author-link icon-link"><a href="{{.}}">{{.}}</a></span>{{end}}
+  </div>
+</section>
+{{end}}


### PR DESCRIPTION
Cleaned up the code that renders section class="author" in the single layout. Extracted to a
partial, "author.html". Introduced .Params.noauthor to remove the author block entirely.
Introduced a map-based lookup into .Site.Data.authors, based on either a per-page .Params.author
key, or a default .Site.Params.author. Added additional checks to keep new authors partial backwards
compatible with the existing hugo-theme-casper .Site.Params.author/authorlocation/authorwebsite/bio.