### PR TITLE
Show (multiple) author on li.

### DIFF
--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -10,10 +10,13 @@
         {{if .Site.Params.logo }}
             <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
         {{end}}
-        {{if .Site.Params.author}}
+        {{if and (ne .Params.author .Site.Params.author) .Params.author}}
+        {{$author := index .Site.Data.authors .Params.author }}
+            {{$author.name}}
+        {{else if .Site.Params.author}}
             {{.Site.Params.author}}
         {{end}}
-        {{if .Params.tags }}on 
+        {{if .Params.tags }}on
             {{ range $index, $tag := .Params.tags }}
                 <a href="{{$baseurl}}tags/{{ $tag | urlize }}/">#{{ $tag }}</a>,
             {{ end }}
@@ -23,6 +26,3 @@
         </time>
     </footer>
 </article>
-
-
-


### PR DESCRIPTION
If you specify an author in content it does not display the author in the list. This pull request adds that functionality.