### PR TITLE
Added some more multi author support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ website: http://example.com
 
 ```
 
+Example override author per page file:
+``` toml
++++
+author = ""
+date = "2014-07-11T10:54:24+02:00"
+title = ""
+...
++++
+
+Contents here
+
+```
+
 ## Menu configuration
 
 On top right of the screen, a "Subscribe" button is displayed with a link to the RSS feed.
@@ -117,6 +130,7 @@ Example of a menu definition in main config file.
 
 ``` toml
 +++
+author = ""
 date = "2014-07-11T10:54:24+02:00"
 draft = false
 title = "dotScale 2014 as a sketch"

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -8,4 +8,5 @@ image = ""
 comments = true	# set false to hide Disqus
 share = true	# set false to hide share buttons
 menu= ""		# set "main" to add this content to the main menu
+author = ""
 +++

--- a/layouts/_default/li.html
+++ b/layouts/_default/li.html
@@ -10,10 +10,13 @@
         {{if .Site.Params.logo }}
             <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
         {{end}}
-        {{if .Site.Params.author}}
+        {{if and (ne .Params.author .Site.Params.author) .Params.author}}
+        {{$author := index .Site.Data.authors .Params.author }}
+            {{$author.name}}
+        {{else if .Site.Params.author}}
             {{.Site.Params.author}}
         {{end}}
-        {{if .Params.tags }}on 
+        {{if .Params.tags }}on
             {{ range $index, $tag := .Params.tags }}
                 <a href="{{$baseurl}}tags/{{ $tag | urlize }}/">#{{ $tag }}</a>,
             {{ end }}
@@ -23,6 +26,3 @@
         </time>
     </footer>
 </article>
-
-
-


### PR DESCRIPTION
Hi @vjeantet 

I added some more support for multiple authors.

1. The "list" page ignores the author specified in a particular post. Now the author's name will appear in any "list" page. I added some additional checking to (hopefully) not break the existing options of author in the main config and no author.
2. Added author to archtypes.
3. Updated readme to better include info on number 2 above.