### PR TITLE
Modify example of BaseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ blog source : https://github.com/vjeantet/vjeantet.fr
 **config.toml**
 
 ``` toml
-BaseUrl= "http://example.com"
+BaseUrl= "http://example.com/"
 LanguageCode= "fr-FR"
 Title= "My blog is awesome"
 paginate = 5


### PR DESCRIPTION
```BaseUrl= "http://example.com"``` is confusing.

I think error occurs on this code.
```
<link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}css/screen.css" />
```


```BaseUrl= "http://example.com/"``` is better.

