### PR TITLE
custom sections in header and footer, via partials

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,6 +8,8 @@
     <script type="text/javascript" src="{{.Site.BaseURL}}js/jquery.js"></script>
     <script type="text/javascript" src="{{.Site.BaseURL}}js/jquery.fitvids.js"></script>
     <script type="text/javascript" src="{{.Site.BaseURL}}js/index.js"></script>
-
+    {{ if .Site.Params.customFooterPartial }}
+        {{ partial .Site.Params.customFooterPartial . }}
+    {{ end }}
 </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="{{.Site.LanguageCode}}">
 <head>
-    
+
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
   	<meta property="og:title" content="{{ if ne .URL "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}" />
   	<meta property="og:site_name" content="{{ .Site.Title }}" />
   	<meta property="og:url" content="{{ .Permalink }}" />
-    
+
     {{ if .IsPage }}
   	<meta property="og:type" content="article" />
 
@@ -32,7 +32,7 @@
 
     <link rel="shortcut icon" href="{{.Site.BaseURL}}images/favicon.ico">
 	  <link rel="apple-touch-icon" href="{{.Site.BaseURL}}images/apple-touch-icon.png" />
-    
+
     <link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}css/screen.css" />
     <link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}css/nav.css" />
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400|Inconsolata" />
@@ -64,6 +64,10 @@
 
     </script>
     {{end}}
+
+    {{ if .Site.Params.customHeaderPartial }}
+        {{ partial .Site.Params.customHeaderPartial . }}
+    {{ end }}
 </head>
 <body class="nav-closed">
 


### PR DESCRIPTION
- provision to add optional custom header partial, and customer footer partial
- useful for adding own `<script/>` tags (for JS) and `<link/>` tags (for CSS)

```toml
[params]
  customFooterPartial = "customFooter.html"
  customHeaderPartial = "customHeader.html"
```