### PR TITLE
add instagram, pinterest, and google+

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -61,23 +61,7 @@
 
     {{ partial "author.html" . }}
 
-    {{ if ne .Params.share false}}
-    <section class="share">
-      <h4>Share this {{ if .Type }}{{.Type}}{{else}}post{{end}}</h4>
-      <a class="icon-twitter" style="font-size: 1.4em" href="https://twitter.com/share?text={{ .Title | safeHTML}}&amp;url={{ .Permalink }}"
-          onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
-          <span class="hidden">Twitter</span>
-      </a>
-      <a class="icon-facebook" style="font-size: 1.4em" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
-          onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
-          <span class="hidden">Facebook</span>
-      </a>
-      <a class="icon-google-plus" style="font-size: 1.4em" href="https://plus.google.com/share?url={{ .Permalink }}"
-         onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-          <span class="hidden">Google+</span>
-      </a>
-    </section>
-    {{end}}
+    {{ partial "share.html" . }}
 
     {{ if ne .Params.comments false}}
     {{ with .Site.DisqusShortname }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,6 +38,22 @@
                     <span class="icon-facebook" style="color:white;font-size:2em"></span>
                 </a>
             {{end}}
+            {{ if .Site.Params.instagramName }}
+                <a class="bloglogo" href="https://instagram.com/{{ .Site.Params.instagramName }}">
+                    <span class="icon-instagram" style="color:white;font-size:2em"></span>
+                </a>
+            {{end}}
+            {{ if .Site.Params.pinterestName }}
+                <a class="bloglogo" href="https://www.pinterest.com/{{ .Site.Params.pinterestName }}">
+                    <span class="icon-pinterest" style="color:white;font-size:2em"></span>
+                </a>
+            {{end}}
+            {{ if .Site.Params.googlePlusName }}
+                <a class="bloglogo" href="https://google.com/+{{ .Site.Params.googlePlusName }}">
+                    <span class="icon-google-plus" style="color:white;font-size:2em"></span>
+                </a>
+            {{end}}
+
             <h1 class="page-title">{{ .Site.Title }}</h1>
             <h2 class="page-description">{{ .Site.Params.description }}</h2>
         </div>

--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -116,23 +116,7 @@
 
     {{ partial "author.html" . }}
 
-    {{ if ne .Params.share false}}
-    <section class="share">
-      <h4>Share this {{ if .Type }}{{.Type}}{{else}}post{{end}}</h4>
-      <a class="icon-twitter" style="font-size: 1.4em" href="https://twitter.com/share?text={{ .Title | safeHTML}}&amp;url={{ .Permalink }}"
-          onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
-          <span class="hidden">Twitter</span>
-      </a>
-      <a class="icon-facebook" style="font-size: 1.4em" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
-          onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
-          <span class="hidden">Facebook</span>
-      </a>
-      <a class="icon-google-plus" style="font-size: 1.4em" href="https://plus.google.com/share?url={{ .Permalink }}"
-         onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-          <span class="hidden">Google+</span>
-      </a>
-    </section>
-    {{end}}
+    {{ partial "share.html" . }}
 
     {{ if ne .Params.comments false}}
     {{ with .Site.DisqusShortname }}

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -158,23 +158,7 @@
 
     {{ partial "author.html" . }}
 
-    {{ if ne .Params.share false}}
-    <section class="share">
-      <h4>Share this {{ if .Type }}{{.Type}}{{else}}post{{end}}</h4>
-      <a class="icon-twitter" style="font-size: 1.4em" href="https://twitter.com/share?text={{ .Title | safeHTML}}&amp;url={{ .Permalink }}"
-          onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
-          <span class="hidden">Twitter</span>
-      </a>
-      <a class="icon-facebook" style="font-size: 1.4em" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
-          onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
-          <span class="hidden">Facebook</span>
-      </a>
-      <a class="icon-google-plus" style="font-size: 1.4em" href="https://plus.google.com/share?url={{ .Permalink }}"
-         onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-          <span class="hidden">Google+</span>
-      </a>
-    </section>
-    {{end}}
+    {{ partial "share.html" . }}
 
     {{ if ne .Params.comments false}}
     {{ with .Site.DisqusShortname }}

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -1,0 +1,21 @@
+{{ if ne .Params.share false}}
+<section class="share">
+  <h4>Share this {{ if .Type }}{{.Type}}{{else}}post{{end}}</h4>
+  <a class="icon-twitter" style="font-size: 1.4em" href="https://twitter.com/share?text={{ .Title | safeHTML}}&amp;url={{ .Permalink }}"
+      onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
+      <span class="hidden">Twitter</span>
+  </a>
+  <a class="icon-facebook" style="font-size: 1.4em" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
+      onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
+      <span class="hidden">Facebook</span>
+  </a>
+  <a class="icon-pinterest" style="font-size: 1.4em" href="http://pinterest.com/pin/create/button/?url={{ .Permalink }}{{ if .Params.pinterestmedia }}&amp;media={{ .Site.BaseURL }}{{ .Params.pinterestmedia }}{{ end }}&amp;description={{ .Title | safeHTML}}"
+      onclick="window.open(this.href, 'pinterest-share','width=580,height=296');return false;">
+      <span class="hidden">Pinterest</span>
+  </a>
+  <a class="icon-google-plus" style="font-size: 1.4em" href="https://plus.google.com/share?url={{ .Permalink }}"
+     onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
+      <span class="hidden">Google+</span>
+  </a>
+</section>
+{{end}}

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -153,6 +153,12 @@ table { border-collapse: collapse; border-spacing: 0; }
 .icon-facebook:before {
     content: "\f203";
 }
+.icon-instagram:before {
+    content: "\f215";
+}
+.icon-pinterest:before {
+    content: "\f210";
+}
 .icon-arrow-left:before {
     content: "\f431";
 }
@@ -1157,7 +1163,7 @@ body:not(.post-template) .post-title {
     position: absolute;
     top: 6rem;
     right: 0;
-    width: 140px;
+    width: 180px;
 }
 
 .post-footer .share a {


### PR DESCRIPTION
- In the banner of the cover page, link to social media accounts
- Add instagram, pinterest, and google plus
- In `config.toml`:

```toml
[params]
  instagramName = "foobar"
  pinterestName = "foobar"
  googlePlusName = "foobar"
```

- Each page's social share button also adds Pinterest
- Optionally (but recommended) can set media in front matter of markdown file

```toml
pinterestMedia = "images/foobar.png"
```