### PR TITLE
adding "authoravatar" config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ canonifyurls = true
   author = "Valère JEANTET"
   authorlocation = "Paris, France"
   authorwebsite = "http://vjeantet.fr"
+  authoravatar = "images/avatar.png"
   bio= "my bio"
   logo = "images/logo.png"
   googleAnalyticsUserID = "UA-79101-12"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,6 @@
 {{ partial "header.html" . }}
 {{ $baseurl := .Site.BaseURL }}
+{{$author := index .Site.Author (or .Params.author .Site.Params.author)}}
 
 {{if .Params.image}}
 <header class="main-header post-head" style="background-image: url({{ $baseurl }}{{.Params.image}})">
@@ -53,9 +54,13 @@
   <footer class="post-footer">
 
 
-    {{if .Site.Params.authoravatar}}
+    {{if $author.thumbnail}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.authoravatar}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{$author.thumbnail}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+    </figure>
+    {{else if .Site.Params.logo}}
+    <figure class="author-image">
+      <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.logo}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
     </figure>
     {{end}}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -53,9 +53,9 @@
   <footer class="post-footer">
 
 
-    {{if .Site.Params.logo}}
+    {{if .Site.Params.authoravatar}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.logo}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.authoravatar}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
     </figure>
     {{end}}
 

--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 {{ $baseurl := .Site.BaseURL }}
-
+{{$author := index .Site.Author (or .Params.author .Site.Params.author)}}
 
 {{if .Params.image}}
 <header class="main-header post-head" style="background-image: url({{ $baseurl }}{{.Params.image}})">
@@ -107,10 +107,13 @@
 
   <footer class="post-footer">
 
-
-    {{if .Site.Params.authoravatar}}
+    {{if $author.thumbnail}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.authoravatar}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{$author.thumbnail}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+    </figure>
+    {{else if .Site.Params.logo}}
+    <figure class="author-image">
+      <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.logo}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
     </figure>
     {{end}}
 

--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -108,9 +108,9 @@
   <footer class="post-footer">
 
 
-    {{if .Site.Params.logo}}
+    {{if .Site.Params.authoravatar}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.logo}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.authoravatar}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
     </figure>
     {{end}}
 

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -1,6 +1,6 @@
 {{ partial "header.html" . }}
 {{ $baseurl := .Site.BaseURL }}
-
+{{$author := index .Site.Author (or .Params.author .Site.Params.author)}}
 
 {{if .Params.image}}
 <header class="main-header post-head" style="background-image: url({{ $baseurl }}{{.Params.image}})">
@@ -149,10 +149,13 @@
 
   <footer class="post-footer">
 
-
-    {{if .Site.Params.authoravatar}}
+    {{if $author.thumbnail}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.authoravatar}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{$author.thumbnail}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+    </figure>
+    {{else if .Site.Params.logo}}
+    <figure class="author-image">
+      <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.logo}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
     </figure>
     {{end}}
 

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -150,9 +150,9 @@
   <footer class="post-footer">
 
 
-    {{if .Site.Params.logo}}
+    {{if .Site.Params.authoravatar}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.logo}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{ $baseurl }}{{.Site.Params.authoravatar}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
     </figure>
     {{end}}
 

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -1,19 +1,15 @@
-{{ if not .Params.noauthor }}
-{{$author := index .Site.Data.authors (or .Params.author .Site.Params.author)}}
-{{$authorname := or $author.name .Site.Params.author }}
-{{$authorbio := or $author.bio .Site.Params.bio }}
-{{$authorlocation := or $author.location .Site.Params.authorlocation }}
-{{$authorwebsite := or $author.website .Site.Params.authorwebsite }}
+{{ if or .Params.author .Site.Params.author }}
+{{$author := index .Site.Author (or .Params.author .Site.Params.author)}}
 <section class="author">
-  <h4><a href="{{.Site.BaseURL}}">{{$authorname}}</a></h4>
-  {{if $authorbio}}
-  <p>{{$authorbio}}</p>
+  <h4><a href="{{.Site.BaseURL}}">{{$author.name}}</a></h4>
+  {{if $author.bio}}
+  <p>{{$author.bio}}</p>
   {{else}}
   <p>Read <a href="{{.Site.BaseURL}}">more posts</a> by this author.</p>
   {{end}}
   <div class="author-meta">
-    {{with $authorlocation}}<span class="author-location icon-location">{{.}}</span>{{end}}
-    {{with $authorwebsite}}<span class="author-link icon-link"><a href="{{.}}">{{.}}</a></span>{{end}}
+    {{with $author.location}}<span class="author-location icon-location">{{.}}</span>{{end}}
+    {{with $author.website}}<span class="author-link icon-link"><a href="{{.}}">{{.}}</a></span>{{end}}
   </div>
 </section>
 {{end}}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -10,8 +10,8 @@
         {{$author := index .Site.Data.authors .Params.author }}
         {{ if isset $author "thumbnail" }}
             <img class="author-thumb" src="{{ .Site.BaseURL }}{{ $author.thumbnail }}" alt="Author image" nopin="nopin" />
-        {{else if .Site.Params.logo }}
-            <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
+        {{else if .Site.Params.authoravatar }}
+            <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.authoravatar}}" alt="Author image" nopin="nopin" />
         {{end}}
         {{if and (ne .Params.author .Site.Params.author) .Params.author}}
         {{$author := index .Site.Data.authors .Params.author }}

--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -1,4 +1,6 @@
 {{ $baseurl := .Site.BaseURL }}
+{{$author := index .Site.Author (or .Params.author .Site.Params.author)}}
+
 <article class="post {{ .Section }}">
     <header class="post-header">
         <h2 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
@@ -7,11 +9,10 @@
         <p>{{ .Summary }} <a class="read-more" href="{{.RelPermalink}}">&raquo;</a></p>
     </section>
     <footer class="post-meta">
-        {{$author := index .Site.Data.authors .Params.author }}
-        {{ if isset $author "thumbnail" }}
+        {{ if $author.thumbnail }}
             <img class="author-thumb" src="{{ .Site.BaseURL }}{{ $author.thumbnail }}" alt="Author image" nopin="nopin" />
-        {{else if .Site.Params.authoravatar }}
-            <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.authoravatar}}" alt="Author image" nopin="nopin" />
+        {{else if .Site.Params.logo }}
+            <img class="author-thumb" src="{{ .Site.BaseURL }}{{.Site.Params.logo}}" alt="Author image" nopin="nopin" />
         {{end}}
         {{if and (ne .Params.author .Site.Params.author) .Params.author}}
         {{$author := index .Site.Data.authors .Params.author }}


### PR DESCRIPTION
Hi @vjeantet, merci beaucoup for creating this hugo theme! I started porting the original from Ghost and then I found hugo's theme repository and saw that you had already done the hard work for me ;) 

I noticed that currently the `logo` variable on `config.toml` represents *two* states:

- the logo at the top-left of the website
- the picture for the post’s author

If you want to have a picture of the author that is *not* the same as the logo, it's not currently supported.

This PR uncouples this relationship and creates an explicit configuration for each. `logo` now only represents the image at the left-hand corner of the website and the new `authoravatar` represents
the image of the author.

I've also updated the `README.md` so that the documentation reflects these changes.

Let me know if this makes sense and is good to merge into your origin. 

Again, thanks so much for the work here!!
--Dennis