### PR TITLE
Fix unexpected underline for social icons

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,7 +29,7 @@
             &nbsp;
             {{end}}
             {{ if .Site.Params.githubName }}
-                <a  href="https://github.com/{{ .Site.Params.githubName }}" target="_blank">
+                <a class="bloglogo" href="https://github.com/{{ .Site.Params.githubName }}" target="_blank">
                 <span class="icon-github" style="color:white;font-size:2em"></span>
                 </a>
             &nbsp;
@@ -90,7 +90,7 @@
             {{ $.Scratch.Set "paginatedSections" "post" }}
         {{ end }}
     {{ end }}
-    
+
     {{ $list := where .Data.Pages "Section" "in" ($.Scratch.Get "paginatedSections") }}
     {{ $list := where $list "Section" "!=" "" }}
     {{ $paginator := .Paginate ( $list ) }}

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -520,6 +520,10 @@ body.nav-opened .site-wrapper {
     width: 80%;
 }
 
+.main-header a.bloglogo {
+    text-decoration: none;
+}
+
 .main-nav {
     position: relative;
     padding: 35px 40px;


### PR DESCRIPTION
Explicitly set text-decoration to none to avoid `a:-webkit-any-link`
applying on social icons. Also add a missing `bloglogo` class back.

Signed-off-by: kfei <kfei@kfei.net>