### PR TITLE
Remove the 'tag-head' class from header.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -2,9 +2,9 @@
 
 {{if .Site.Params.cover}}
 {{if or (eq (substr .Site.Params.cover 0 7) "http://") (eq (substr .Site.Params.cover 0 8) "https://")}}
-  <header class="main-header tag-head" style="background-image: url({{.Site.Params.cover}})">
+  <header class="main-header" style="background-image: url({{.Site.Params.cover}})">
   {{ else }}
-  <header class="main-header tag-head" style="background-image: url({{.Site.BaseURL}}{{.Site.Params.cover}})">
+  <header class="main-header" style="background-image: url({{.Site.BaseURL}}{{.Site.Params.cover}})">
   {{ end }}
 {{else}}
 <header class="main-header no-cover">


### PR DESCRIPTION
The previous commit had accidentally copied a 'tag-head' class from list.html to index.html. This caused the index's cover image to be cropped too much.