### PR TITLE
Support excerpt variable

### DIFF
--- a/layouts/partials/li.html
+++ b/layouts/partials/li.html
@@ -4,7 +4,13 @@
         <h2 class="post-title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
     </header>
     <section class="post-excerpt">
-        <p>{{ .Summary }} <a class="read-more" href="{{.RelPermalink}}">&raquo;</a></p>
+        {{if isset .Params "excerpt" }}
+            {{ if .Params.excerpt }}
+                <p>{{ .Params.excerpt }} <a class="read-more" href="{{.RelPermalink}}">&raquo;</a></p>
+            {{end}}
+        {{else}}
+            <p>{{ .Summary }} <a class="read-more" href="{{.RelPermalink}}">&raquo;</a></p>
+        {{end}}
     </section>
     <footer class="post-meta">
         {{$author:= .Site.Params.author}}


### PR DESCRIPTION
Hugo generates summaries for posts which can be used with the .Summary
page variable. The theme uses this to print the summary of each post
in the post list. As it is now, you cannot disable the summary
from being printed, so the partial header li.html is changed
to support the excerpt variable in posts.

When posts do not have an excerpt variable, the behavior is not changed
and the summary is being printed as before. If excerpt exists
and is not empty, then it is printed instead of the summary and if excerpt
is empty, then nothing is printed.
