### PR TITLE
Add syntax highlighting for code tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ blog source : https://github.com/vjeantet/vjeantet.fr
 * Tagging
 * Pagination
 * Menu
+* Syntax Highlighting
 
 # Theme usage and asumptions
 * All blog posts are in the ```post``` folder (```content/post```)
@@ -66,6 +67,10 @@ canonifyurls = true
   # linkedinName = ""
   # set true if you are not proud of using Hugo (true will hide the footer note "Proudly published with HUGO.....")
   hideHUGOSupport = false
+  # Setting a value will load highlight.js and enable syntax highlighting using the style selected.
+  # See https://github.com/isagalaev/highlight.js/tree/master/src/styles for available styles
+  # A preview of above styles can be viewed at https://highlightjs.org/static/demo/
+  hjsStyle = "default"
 
 ```
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -37,6 +37,11 @@
     <link rel="stylesheet" type="text/css" href="{{.Site.BaseURL}}css/nav.css" />
     <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Merriweather:300,700,700italic,300italic|Open+Sans:700,400|Inconsolata" />
 
+    {{ if .Site.Params.hjsStyle }}
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/{{ .Site.Params.hjsStyle }}.min.css">
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+        <script>hljs.initHighlightingOnLoad();</script>
+    {{end}}
 
     {{ if .Site.Params.RSSLink}}
         <link href="{{.Site.Params.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />


### PR DESCRIPTION
Add support for syntax highlighting using highlight.js

If the user sets a value to the parameter hjsStyle, the the js script highlight.js will be loaded and colorize code tags using the style selected by the user.

I know that there is support for custom partial headers, so users can individually load highlight.js there, but i think it is a feature many people use, so it is nice to have support for it.
