### PR TITLE
Move social icons into partial header

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -22,24 +22,8 @@
     </nav>
     <div class="vertical">
         <div class="main-header-content inner">
-            {{ if .Site.Params.linkedinName }}
-                <a class="bloglogo" href="https://www.linkedin.com/in/{{ .Site.Params.linkedinName }}">
-                    <span class="icon-linkedin" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.githubName }}
-                <a  href="https://github.com/{{ .Site.Params.githubName }}">
-                <span class="icon-github" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.twitterName }}
-                <a class="bloglogo" href="https://twitter.com/{{ .Site.Params.twitterName }}">
-                    <span class="icon-twitter" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
+
+            {{ partial "social.html" . }}
 
             <h1 class="page-title">{{ .Site.Title }}</h1>
             <h2 class="page-description">{{ .Site.Params.description }}</h2>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -26,48 +26,8 @@
     </nav>
     <div class="vertical">
         <div class="main-header-content inner">
-            {{ if .Site.Params.linkedinName }}
-                <a class="bloglogo" href="https://www.linkedin.com/in/{{ .Site.Params.linkedinName }}" target="_blank">
-                    <span class="icon-linkedin" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.githubName }}
-                <a class="bloglogo" href="https://github.com/{{ .Site.Params.githubName }}" target="_blank">
-                <span class="icon-github" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.twitterName }}
-                <a class="bloglogo" href="https://twitter.com/{{ .Site.Params.twitterName }}" target="_blank">
-                    <span class="icon-twitter" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.facebookName }}
-                <a class="bloglogo" href="https://www.facebook.com/{{ .Site.Params.facebookName }}" target="_blank">
-                    <span class="icon-facebook" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.instagramName }}
-                <a class="bloglogo" href="https://instagram.com/{{ .Site.Params.instagramName }}" target="_blank">
-                    <span class="icon-instagram" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.pinterestName }}
-                <a class="bloglogo" href="https://www.pinterest.com/{{ .Site.Params.pinterestName }}" target="_blank">
-                    <span class="icon-pinterest" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
-            {{ if .Site.Params.googlePlusName }}
-                <a class="bloglogo" href="https://google.com/+{{ .Site.Params.googlePlusName }}" target="_blank">
-                    <span class="icon-google-plus" style="color:white;font-size:2em"></span>
-                </a>
-            &nbsp;
-            {{end}}
+
+            {{ partial "social.html" . }}
 
             <h1 class="page-title">{{ .Site.Title }}</h1>
             <h2 class="page-description">{{ .Site.Params.description }}</h2>

--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -1,0 +1,48 @@
+{{ if .Site.Params.linkedinName }}
+    <a class="bloglogo" href="https://www.linkedin.com/in/{{ .Site.Params.linkedinName }}" target="_blank">
+        <span class="icon-linkedin" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}
+
+{{ if .Site.Params.githubName }}
+    <a class="bloglogo" href="https://github.com/{{ .Site.Params.githubName }}" target="_blank">
+    <span class="icon-github" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}
+
+{{ if .Site.Params.twitterName }}
+    <a class="bloglogo" href="https://twitter.com/{{ .Site.Params.twitterName }}" target="_blank">
+        <span class="icon-twitter" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}
+
+{{ if .Site.Params.facebookName }}
+    <a class="bloglogo" href="https://www.facebook.com/{{ .Site.Params.facebookName }}" target="_blank">
+        <span class="icon-facebook" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}
+
+{{ if .Site.Params.instagramName }}
+    <a class="bloglogo" href="https://instagram.com/{{ .Site.Params.instagramName }}" target="_blank">
+        <span class="icon-instagram" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}
+
+{{ if .Site.Params.pinterestName }}
+    <a class="bloglogo" href="https://www.pinterest.com/{{ .Site.Params.pinterestName }}" target="_blank">
+        <span class="icon-pinterest" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}
+
+{{ if .Site.Params.googlePlusName }}
+    <a class="bloglogo" href="https://google.com/+{{ .Site.Params.googlePlusName }}" target="_blank">
+        <span class="icon-google-plus" style="color:white;font-size:2em"></span>
+    </a>
+&nbsp;
+{{end}}


### PR DESCRIPTION
It is likely that users will want to add more social icons so i moved them to a separate partial header to make it easier for someone to change the file. Also, the icons were being used both in index.html and 404.html, so it also avoids code duplication.

However, there was a discrepancy between index and 404. The 404 page had support only for linkedin, github, twitter and not for the ones that were added with pull request #31. Another difference is that index was changed with pull request #35 to use target="_blank".

Were these changes deliberately not made in 404 or it was just missed ? I chose to use the index version of the code because it was more complete.

I also intended to add more icons for bitbucket, gitlab, etc but there are no icons for them in genericons so the code would need to change to use font-awesome instead and it was quite an intrusive modification so i left it out. Do you think it would be better to use font-awesome or it isn't worth it ?
