### PR TITLE
Added og:image statement

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -10,6 +10,14 @@
   	<meta property="og:title" content="{{ if ne .URL "/" }} {{ .Title }} &middot; {{ end }} {{ .Site.Title }}" />
   	<meta property="og:site_name" content="{{ .Site.Title }}" />
   	<meta property="og:url" content="{{ .Permalink }}" />
+    
+    {{if .Params.image }}
+       <meta property="og:image" content="{{ .Site.BaseURL }}{{.Params.image}}"/>
+    {{else}}
+        {{if .Site.Params.cover}}
+            <meta property="og:image" content="{{ .Site.BaseURL }}{{.Site.Params.cover}}"/>
+        {{end}}
+    {{end}}
 
     {{ if .IsPage }}
   	<meta property="og:type" content="article" />


### PR DESCRIPTION
This allows Facebook to get the header image properly as well, and uses the correct og:image tag to do so.