### PR TITLE
Added icons for flickr and email on cover page

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -43,7 +43,8 @@
                 <span class="icon-flickr" style="color:white;font-size:2em"></span>
                 </a>
             &nbsp;
-            {{end}}            {{ if .Site.Params.twitterName }}
+            {{end}}            
+            {{ if .Site.Params.twitterName }}
                 <a class="bloglogo" href="https://twitter.com/{{ .Site.Params.twitterName }}" target="_blank">
                     <span class="icon-twitter" style="color:white;font-size:2em"></span>
                 </a>
@@ -58,6 +59,12 @@
             {{ if .Site.Params.instagramName }}
                 <a class="bloglogo" href="https://instagram.com/{{ .Site.Params.instagramName }}" target="_blank">
                     <span class="icon-instagram" style="color:white;font-size:2em"></span>
+                </a>
+            &nbsp;
+            {{end}}
+            {{ if .Site.Params.email }}
+                <a class="bloglogo" href="mailto:{{ .Site.Params.email }}" target="_blank">
+                    <span class="icon-mail" style="color:white;font-size:2em"></span>
                 </a>
             &nbsp;
             {{end}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -38,7 +38,12 @@
                 </a>
             &nbsp;
             {{end}}
-            {{ if .Site.Params.twitterName }}
+            {{ if .Site.Params.flickrName }}
+                <a class="bloglogo" href="https://flickr.com/{{ .Site.Params.flickrName }}" target="_blank">
+                <span class="icon-flickr" style="color:white;font-size:2em"></span>
+                </a>
+            &nbsp;
+            {{end}}            {{ if .Site.Params.twitterName }}
                 <a class="bloglogo" href="https://twitter.com/{{ .Site.Params.twitterName }}" target="_blank">
                     <span class="icon-twitter" style="color:white;font-size:2em"></span>
                 </a>

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -148,6 +148,12 @@ table { border-collapse: collapse; border-spacing: 0; }
 .icon-twitter:before {
     content: "\f202";
 }
+.icon-flickr:before {
+    content: "\f211";
+}
+.icon-mail:before {
+    content: "\f410";
+}
 .icon-google-plus:before {
     content: "\f206";
 }


### PR DESCRIPTION
When adding the properties flickrName or email in the [params] section of config.toml the relevant icons will be shown on the cover page.
Example on https://hallgeirholien.no
