### PR TITLE
Add suggestions on other sections than « page »

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -74,6 +74,8 @@
 
 </main>
 
-{{ partial "suggestions.html" . }}
+{{if not .Params.hideSuggestions }}
+  {{ partial "suggestions.html" . }}
+{{ end }}
 
 {{ partial "footer.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -73,4 +73,7 @@
 </article>
 
 </main>
+
+{{ partial "suggestions.html" . }}
+
 {{ partial "footer.html" . }}

--- a/layouts/partials/suggestions.html
+++ b/layouts/partials/suggestions.html
@@ -1,5 +1,5 @@
 <aside class="read-next">
-  {{ with .Next }}
+  {{ with .NextInSection }}
       <a class="read-next-story" style="{{ if .Params.image }}background-image: url({{ .Site.BaseURL }}{{ .Params.image }}){{ else }}no-cover{{ end }}" href="{{ .RelPermalink }}">
           <section class="post">
               <h2>{{.Title}}</h2>
@@ -7,7 +7,7 @@
           </section>
       </a>
   {{ end }}
-  {{ with .Prev }}
+  {{ with .PrevInSection }}
       <a class="read-next-story prev" style="{{ if .Params.image }}background-image: url({{ .Site.BaseURL }}{{ .Params.image }}){{ else }}no-cover{{ end }}" href="{{ .RelPermalink }}">
           <section class="post">
               <h2>{{.Title}}</h2>


### PR DESCRIPTION
Currently suggestions are only visible for the page section and show content from other sections.

This PR makes them available on other sections.