### PR TITLE
Add support for extra highlight.js languages

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,8 +56,8 @@
     {{ if .Site.Params.hjsStyle }}
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/{{ .Site.Params.hjsStyle }}.min.css">
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
-        {{ if .Site.Params.hjsExtraLanguages }}
-          {{ range $index, $language := .Site.Params.hjsExtraLanguages }}
+        {{ if or .Site.Params.hjsExtraLanguages .Params.hjsExtraLanguages }}
+          {{ range $index, $language := (union .Site.Params.hjsExtraLanguages .Params.hjsExtraLanguages) }}
             <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/{{ $language }}.min.js"></script>
           {{ end }}
         {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -54,8 +54,13 @@
     {{ end }}
 
     {{ if .Site.Params.hjsStyle }}
-        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/styles/{{ .Site.Params.hjsStyle }}.min.css">
-        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.6.0/highlight.min.js"></script>
+        <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/{{ .Site.Params.hjsStyle }}.min.css">
+        <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
+        {{ if .Site.Params.hjsExtraLanguages }}
+          {{ range $index, $language := .Site.Params.hjsExtraLanguages }}
+            <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/{{ $language }}.min.js"></script>
+          {{ end }}
+        {{ end }}
         <script>hljs.initHighlightingOnLoad();</script>
     {{end}}
 


### PR DESCRIPTION
This adds support for extra highlight.js languages by assigning an array to either _config.toml_ or a page/post's front matter:

_config.toml_

```toml
# ...
[params]
  # ...
  hjsStyle = "default"
  hjsExtraLanguages = ["elm"]
```

_content/post/my-blog-post-about-elm.md_

```
+++
title = "My Blog Post About Elm"
# ...
hjsExtraLanguages = ["elm"]
+++

...
```

I've also upgraded highlight.js from v9.6.0 to v9.8.0