### PR TITLE
Added current date to archtype default

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -8,4 +8,5 @@ comments = true	# set false to hide Disqus
 share = true	# set false to hide share buttons
 menu= ""		# set "main" to add this content to the main menu
 author = ""
+title = ""
 +++

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,6 @@
 +++
 draft = true
+date = "{{ .Date }}"
 slug = "post-title"
 tags = ["tag1","tag2"]
 image = ""

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,12 +1,12 @@
 +++
-draft = true
+author = ""
+comments = true	# set false to hide Disqus
 date = "{{ .Date }}"
+draft = true
+image = ""
+menu = ""		# set "main" to add this content to the main menu
+share = true	# set false to hide share buttons
 slug = "post-title"
 tags = ["tag1","tag2"]
-image = ""
-comments = true	# set false to hide Disqus
-share = true	# set false to hide share buttons
-menu= ""		# set "main" to add this content to the main menu
-author = ""
 title = ""
 +++


### PR DESCRIPTION
Since Hugo v0.24 I was getting the following warning when creating a new post

```
WARNING: date and/or title missing from archetype file "/Users/evils/Repositories/caffeineflo.github.io/themes/casper/archetypes/default.md". 
From Hugo 0.24 this must be provided in the archetype file itself, if needed. Example:
---
title: "{{ replace .TranslationBaseName "-" " " | title }}"
date: {{ .Date }}
draft: true
---
```

To fix the warning and conform to the latest Hugo changes, I reintroduced the data attribute as per this PR.