### PR TITLE
Authoravatar Updates

### DIFF
--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -113,7 +113,7 @@
 
     {{if .Site.Params.logo}}
     <figure class="author-image">
-        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{.Site.Params.logo | relURL}})"><span class="hidden">{{.Site.Params.author}}'s Picture</span></a>
+        <a class="img" href="{{.Site.BaseURL}}" style="background-image: url({{.Site.Params.logo | relURL}})"><span class="hidden">{{.Site.Params.title}}</span></a>
     </figure>
     {{end}}
 

--- a/layouts/partials/author.html
+++ b/layouts/partials/author.html
@@ -4,7 +4,7 @@
 {{$authorbio := or .Params.authorbio .Site.Params.authorbio }}
 {{$authorlocation := or .Params.authorlocation .Site.Params.authorlocation }}
 {{$authorwebsite := or .Params.authorwebsite .Site.Params.authorwebsite }}
-{{$authoravatar := or .Params.authoravatar .Site.Params.logo }}
+{{$authoravatar := or .Params.authoravatar .Site.Params.authoravatar }}
 
 {{with $authoravatar}}
 <figure class="author-image">


### PR DESCRIPTION
Hey @vjeantet,

I found two small things that might be worth a pull request if you feel so as well.

1. When you started using partials and introduced the author partial it was either authoravatar if an author was setup or the site's logo. For all other things such as author location it was either the authors location or the authorlocation from the site settings. I think this was an discrepancy and changed it to choose the authoravatar from the site settings as well instead of the logo.

2. The cover layout showed the Logo with a span of the Authors name. In most cases I would assume the Logo is not the Authors picture. So I changed it to be the site's title to have a better connection between the two things.

Thanks