### PR TITLE
Make cover image option in Twitter card

### DIFF
--- a/layouts/partials/twitter_card.html
+++ b/layouts/partials/twitter_card.html
@@ -8,7 +8,9 @@
     {{ end }}
 {{ else }}
     <meta name="twitter:card" content="summary"/>
+    {{ with .Site.Params.cover }}
     <meta name="twitter:image" content="{{ .Site.Params.cover | relURL }}"/>
+    {{ end }}
 {{ end }}
 
 <!-- Twitter Card data -->


### PR DESCRIPTION
Without a configuration setting for 'cover', the `twitter_card.html`
partial fails to render, and throws errors during site build.

Fixes #95 