### PR TITLE
Twitter card should include cover image if present

### DIFF
--- a/layouts/partials/twitter_card.html
+++ b/layouts/partials/twitter_card.html
@@ -9,7 +9,7 @@
 {{ else }}
     <meta name="twitter:card" content="summary"/>
     {{ with .Site.Params.cover }}
-    <meta name="twitter:image" content="{{ .Site.Params.cover | relURL }}"/>
+    <meta name="twitter:image" content="{{ . | relURL }}"/>
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
This fixes a bug introduced in #96.