### PR TITLE
Icon with link to Stackoverflow user page. Solve #99

### DIFF
--- a/layouts/partials/social.html
+++ b/layouts/partials/social.html
@@ -19,6 +19,13 @@
 &nbsp;
 {{end}}
 
+{{ if .Site.Params.stackoverflowId }}
+<a class="bloglogo" href="https://stackoverflow.com/users/{{ .Site.Params.stackoverflowId }}" target="_blank">
+<img src="https://cdn.sstatic.net/Sites/stackoverflow/company/img/logos/so/so-icon.svg" height="40" width="40">
+</a>
+&nbsp;
+{{end}}
+
 {{ if .Site.Params.twitterName }}
     <a class="bloglogo" href="https://twitter.com/{{ .Site.Params.twitterName }}" target="_blank">
         <span class="icon-twitter" style="color:white;font-size:2em"></span>


### PR DESCRIPTION
I initially considered extending the genericons font with the icon, however no new social icons will be allowed into genericons. (https://github.com/Automattic/Genericons/issues/108)

This proposed change pull an official svg from Stackoverflow.

**To use this:**
If the config.toml contain this:
```
[params]
...
stackoverflowId = "123456"
```
A Stackoverflow logo will appear on the front page with a link to https://stackoverflow.com/users/123456
