### PR TITLE
Use absURL for twitter card

### DIFF
--- a/layouts/partials/twitter_card.html
+++ b/layouts/partials/twitter_card.html
@@ -2,14 +2,14 @@
     {{ with .Params.image }}
         <!-- Twitter summary card with large image must be at least 280x150px -->
         <meta name="twitter:card" content="summary_large_image"/>
-        <meta name="twitter:image" content="{{ .  | relURL }}"/>
+        <meta name="twitter:image" content="{{ .  | absURL }}"/>
     {{ else }}
         <meta name="twitter:card" content="summary"/>
     {{ end }}
 {{ else }}
     <meta name="twitter:card" content="summary"/>
     {{ with .Site.Params.cover }}
-    <meta name="twitter:image" content="{{ . | relURL }}"/>
+    <meta name="twitter:image" content="{{ . | absURL }}"/>
     {{ end }}
 {{ end }}
 


### PR DESCRIPTION
It seems that twitter does not follow relative URL.

demo pages:

* Demo1: https://hoshinotsuyoshi.com/demo1.html)
   * `<meta name="twitter:image" content="/images/euler.jpg"/>`
* Demo2: https://hoshinotsuyoshi.com/demo2.html
   * `<meta name="twitter:image" content="https://hoshinotsuyoshi.com/images/euler.jpg"/>`
 
## Demo1:  with `relURL`

(Using [twitter official tool](https://cards-dev.twitter.com/validator))

<img width="1207" alt="2017-11-21 23 40 39" src="https://user-images.githubusercontent.com/1394049/33078273-7f726936-cf15-11e7-9b67-059e7baa11ae.png">


## Demo2:  with `absURL`

<img width="1204" alt="2017-11-21 23 40 27" src="https://user-images.githubusercontent.com/1394049/33078255-72fc8240-cf15-11e7-8fe4-7af89806dcbd.png">

----

So I think `absURL` is better.