### PR TITLE
Social icons fix

### DIFF
--- a/layouts/partials/home-content.html
+++ b/layouts/partials/home-content.html
@@ -10,7 +10,7 @@
         {{ if .Site.Params.paginatedsections }}
             {{ $.Scratch.Set "paginatedSections" .Site.Params.paginatedsections }}
         {{ else }}
-            {{ $.Scratch.Set "paginatedSections" "post" }}
+            {{ $.Scratch.Set "paginatedSections" "posts" }}
         {{ end }}
     {{ end }}
 

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -1242,7 +1242,6 @@ body:not(.post-template) .post-title {
     position: absolute;
     top: 6rem;
     right: 0;
-    width: 180px;
 }
 
 .post-footer .share a {


### PR DESCRIPTION
Social icons in the post footer wrap onto 2 lines. This is a fix.