### PR TITLE
There's no "union" function, use "intersect"

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -57,7 +57,7 @@
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/styles/{{ .Site.Params.hjsStyle }}.min.css">
         <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/highlight.min.js"></script>
         {{ if or .Site.Params.hjsExtraLanguages .Params.hjsExtraLanguages }}
-          {{ range $index, $language := (union .Site.Params.hjsExtraLanguages .Params.hjsExtraLanguages) }}
+          {{ range $index, $language := (intersect .Site.Params.hjsExtraLanguages .Params.hjsExtraLanguages) }}
             <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.8.0/languages/{{ $language }}.min.js"></script>
           {{ end }}
         {{ end }}


### PR DESCRIPTION
Even if the documentation says there's an "union" function that computes
the union of two sets, looking at Hugo's source code, there's no such
function.

Use "intersect" instead. It's more appropriate, too, because it will
eliminate duplicates in the two lists, if there are any.

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@gmail.com>