### PR TITLE
Remove Google Plus share icon

### DIFF
--- a/layouts/partials/home-content.html
+++ b/layouts/partials/home-content.html
@@ -14,7 +14,7 @@
         {{ end }}
     {{ end }}
 
-    {{ $list := where .Data.Pages "Section" "in" ($.Scratch.Get "paginatedSections") }}
+    {{ $list := where .Site.RegularPages "Section" "in" ($.Scratch.Get "paginatedSections") }}
     {{ $list := where $list "Section" "!=" "" }}
     {{ $paginator := .Paginate ( $list ) }}
 

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -13,9 +13,5 @@
       onclick="window.open(this.href, 'pinterest-share','width=580,height=296');return false;">
       <span class="hidden">Pinterest</span>
   </a>
-  <a class="icon-google-plus" style="font-size: 1.4em" href="https://plus.google.com/share?url={{ .Permalink }}"
-     onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-      <span class="hidden">Google+</span>
-  </a>
 </section>
 {{end}}


### PR DESCRIPTION
As Google are shutting down Google+, there doesn't seem to be much point in having the G+ sharing button on posts anymore.

I haven't cleared out G+ from the "social" params etc.; I recommend that should be done by someone with more knowledge of the inner working of themes.