### PR TITLE
list posts in home page starting at Hugo v.0.57.0

### DIFF
--- a/layouts/partials/home-content.html
+++ b/layouts/partials/home-content.html
@@ -14,7 +14,7 @@
         {{ end }}
     {{ end }}
 
-    {{ $list := where .Data.Pages "Section" "in" ($.Scratch.Get "paginatedSections") }}
+    {{ $list := where .Site.RegularPages "Section" "in" ($.Scratch.Get "paginatedSections") }}
     {{ $list := where $list "Section" "!=" "" }}
     {{ $paginator := .Paginate ( $list ) }}
 


### PR DESCRIPTION
The changes in Hugo v.0.57.0 made this theme not showing posts on the homepage.
See: https://github.com/gohugoio/hugoThemes/issues/682

One line of code fixed this issue in the casper theme and made it work as in previous hugo versions