### PR TITLE
fixed: .Hugo.Generator; .RSSLink; etc. issues.

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -16,7 +16,7 @@
             {{ if .Site.Params.RSSLink}}
               <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
             {{else}}
-              <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+              <a class="menu-button icon-feed" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'>&nbsp;&nbsp;Subscribe</a>
             {{end}}
         {{end}}
     </nav>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -26,7 +26,7 @@
         {{ if .Site.Params.RSSLink}}
           <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'>&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/cover.html
+++ b/layouts/page/cover.html
@@ -22,7 +22,7 @@
         {{ if .Site.Params.RSSLink}}
           <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'>&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/index.html
+++ b/layouts/page/index.html
@@ -20,7 +20,7 @@
             {{ if .Site.Params.RSSLink}}
               <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
             {{else}}
-              <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+              <a class="menu-button icon-feed" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'>&nbsp;&nbsp;Subscribe</a>
             {{end}}
         {{end}}
     </nav>

--- a/layouts/page/list.html
+++ b/layouts/page/list.html
@@ -25,7 +25,7 @@
         {{ if .Site.Params.RSSLink}}
           <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'>&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/page/single.html
+++ b/layouts/page/single.html
@@ -23,7 +23,7 @@
         {{ if .Site.Params.RSSLink}}
           <a class="menu-button icon-feed" href="{{.Site.Params.RSSLink }}">&nbsp;&nbsp;Subscribe</a>
         {{else}}
-          <a class="menu-button icon-feed" href="{{ .RSSLink }}">&nbsp;&nbsp;Subscribe</a>
+          <a class="menu-button icon-feed" href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}'>&nbsp;&nbsp;Subscribe</a>
         {{end}}
       {{end}}
     </nav>

--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,5 +1,5 @@
 {{ if ne .Params.comments false}}
-{{ if .Site.DisqusShortname }}
+{{ if .Site.Config.Services.Disqus.Shortname }}
 <div id="disqus_thread"></div>
 <script>
 
@@ -14,7 +14,7 @@ this.page.identifier = "{{ .Permalink }}"; // Replace PAGE_IDENTIFIER with your 
 
 (function() { // DON'T EDIT BELOW THIS LINE
 var d = document, s = d.createElement('script');
-s.src = 'https://{{ .Site.DisqusShortname }}.disqus.com/embed.js';
+s.src = 'https://{{ .Site.Config.Services.Disqus.Shortname }}.disqus.com/embed.js';
 s.setAttribute('data-timestamp', +new Date());
 (d.head || d.body).appendChild(s);
 })();

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -7,7 +7,7 @@
 
     {{ partial "twitter_card.html" . }}
 
-  	<meta property="og:title" content="{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
+  	<meta property="og:title" content="{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
   	<meta property="og:site_name" content="{{ .Site.Title }}" />
   	<meta property="og:url" content="{{ .Permalink }}" />
 
@@ -32,7 +32,7 @@
     <meta property="og:description" content="{{ .Site.Params.description }}" />
     {{ end }}
 
-    <title>{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}</title>
+    <title>{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}</title>
 
     {{ if .IsPage }}
     <meta name="description" content="{{ .Description | default (substr .Summary 0 160) }}" />
@@ -67,14 +67,14 @@
     {{ if .Site.Params.RSSLink}}
         <link href="{{.Site.Params.RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{else}}
-      {{ if ne .URL "/" }}
+      {{ if ne .Permalink "/" }}
           <link href="{{ "index.xml" | relURL}}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
       {{ end }}
       {{if .IsNode}}
-        <link href="{{.RSSLink}}" rel="alternate" type="application/rss+xml" title="{{ if ne .URL "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
+        <link href='{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}' rel="alternate" type="application/rss+xml" title="{{ if ne .Permalink "/" }}{{ .Title }} &middot; {{ end }}{{ .Site.Title }}" />
       {{end}}
     {{end}}
-    {{.Hugo.Generator}}
+    {{ hugo.Generator }}
 
     <link rel="canonical" href="{{ .Permalink }}" />
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{.Site.LanguageCode}}">
+<html lang="{{.Site.Language.Locale}}">
 <head>
 
     <meta charset="utf-8" />

--- a/layouts/partials/home-content.html
+++ b/layouts/partials/home-content.html
@@ -14,7 +14,7 @@
         {{ end }}
     {{ end }}
 
-    {{ $list := where .Data.Pages "Section" "in" ($.Scratch.Get "paginatedSections") }}
+    {{ $list := where .Site.RegularPages "Section" "in" ($.Scratch.Get "paginatedSections") }}
     {{ $list := where $list "Section" "!=" "" }}
     {{ $paginator := .Paginate ( $list ) }}
 

--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -18,7 +18,7 @@
     {{ if .Site.Params.RSSLink}}
     <a class="subscribe-button icon-feed" href="{{.Site.Params.RSSLink }}">Subscribe</a> </div>
     {{else}}
-    <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{.RSSLink}}{{else}}{{"index.xml" | relURL}}{{end}}">Subscribe</a>
+    <a class="subscribe-button icon-feed" href="{{if .IsNode}}{{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}{{else}}{{"index.xml" | relURL}}{{end}}">Subscribe</a>
     {{end}}
 </div>
 <span class="nav-cover"></span>

--- a/layouts/partials/twitter_card.html
+++ b/layouts/partials/twitter_card.html
@@ -4,10 +4,10 @@
         <meta name="twitter:card" content="summary_large_image"/>
         <meta name="twitter:image" content="{{ .  | relURL }}"/>
     {{ else }}
-        <meta name="twitter:card" content="summary"/>
+        <meta name="referrer" content="no-referrer"/>
     {{ end }}
 {{ else }}
-    <meta name="twitter:card" content="summary"/>
+    <meta name="referrer" content="no-referrer"/>
     {{ with .Site.Params.cover }}
     <meta name="twitter:image" content="{{ . | relURL }}"/>
     {{ end }}


### PR DESCRIPTION
Ref:
https://vincenttam.gitlab.io/post/2019-04-25-replacing-deprecated-hugo-syntax-in-blog-theme/
https://ann.chiramattel.com/post/upgrade-hugo/